### PR TITLE
Refactoring and Fixes

### DIFF
--- a/reeds_shepp.py
+++ b/reeds_shepp.py
@@ -279,7 +279,7 @@ def path7(x, y, phi):
     rho, theta = R(xi, eta)
     u1 = (20 - rho*rho) / 16
 
-    if rho <= 6 and 0 <= u1 and u1 <= 1:
+    if rho <= 6 and 0 <= u1 <= 1:
         u = math.acos(u1)
         A = math.asin(2 * math.sin(u) / rho)
         t = M(theta + math.pi/2 + A)

--- a/reeds_shepp.py
+++ b/reeds_shepp.py
@@ -44,10 +44,12 @@ class PathElement:
         return s
 
     def reverse_steering(self):
-        self.steering = Steering(-self.steering.value)
+        steering = Steering(-self.steering.value)
+        return replace(self, steering=steering)
 
     def reverse_gear(self):
-        self.gear = Gear(-self.gear.value)
+        gear = Gear(-self.gear.value)
+        return replace(self, gear=gear)
 
 
 def path_length(path):
@@ -69,6 +71,7 @@ def get_optimal_path(start, end):
         if L <= L_min:
             L_min, i_min = L, i
     return paths[i_min]
+
 
 def get_all_paths(start, end):
     """
@@ -103,9 +106,7 @@ def timeflip(path):
     """
     timeflip transform described around the end of the article
     """
-    new_path = [replace(e) for e in path]
-    for e in new_path:
-        e.reverse_gear()
+    new_path = [e.reverse_gear() for e in path]
     return new_path
 
 
@@ -113,12 +114,8 @@ def reflect(path):
     """
     reflect transform described around the end of the article
     """
-    new_path = [replace(e) for e in path]
-    for e in new_path:
-        e.reverse_steering()
+    new_path = [e.reverse_steering() for e in path]
     return new_path
-
-
 
 
 def path1(x, y, phi):

--- a/reeds_shepp.py
+++ b/reeds_shepp.py
@@ -130,10 +130,9 @@ def path1(x, y, phi):
     u, t = R(x - math.sin(phi), y - 1 + math.cos(phi))
     v = M(phi - t)
 
-    if t >= 0 and u >= 0 and v >= 0:
-        path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
-        path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
-        path.append(PathElement.create(v, Steering.LEFT, Gear.FORWARD))
+    path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
+    path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+    path.append(PathElement.create(v, Steering.LEFT, Gear.FORWARD))
 
     return path
 
@@ -153,10 +152,9 @@ def path2(x, y, phi):
         t = M(t1 + math.atan2(2, u))
         v = M(t - phi)
 
-        if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
-            path.append(PathElement.create(v, Steering.RIGHT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
+        path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(v, Steering.RIGHT, Gear.FORWARD))
 
     return path
 
@@ -179,10 +177,9 @@ def path3(x, y, phi):
         u = M(math.pi - 2*A)
         v = M(phi - t - u)
 
-        if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement.create(u, Steering.RIGHT, Gear.BACKWARD))
-            path.append(PathElement.create(v, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.RIGHT, Gear.BACKWARD))
+        path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(v, Steering.LEFT, Gear.FORWARD))
 
     return path
 
@@ -205,10 +202,9 @@ def path4(x, y, phi):
         u = M(math.pi - 2*A)
         v = M(t + u - phi)
 
-        if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement.create(u, Steering.RIGHT, Gear.BACKWARD))
-            path.append(PathElement.create(v, Steering.LEFT, Gear.BACKWARD))
+        path.append(PathElement.create(u, Steering.RIGHT, Gear.BACKWARD))
+        path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(v, Steering.LEFT, Gear.BACKWARD))
 
     return path
 
@@ -231,10 +227,9 @@ def path5(x, y, phi):
         t = M(theta + math.pi/2 - A)
         v = M(t - u - phi)
 
-        if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement.create(u, Steering.RIGHT, Gear.FORWARD))
-            path.append(PathElement.create(v, Steering.LEFT, Gear.BACKWARD))
+        path.append(PathElement.create(u, Steering.RIGHT, Gear.FORWARD))
+        path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(v, Steering.LEFT, Gear.BACKWARD))
 
     return path
 
@@ -263,11 +258,10 @@ def path6(x, y, phi):
             u = M(math.pi - A)
             v = M(phi - t + 2*u)
 
-        if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement.create(u, Steering.RIGHT, Gear.FORWARD))
-            path.append(PathElement.create(u, Steering.LEFT, Gear.BACKWARD))
-            path.append(PathElement.create(v, Steering.RIGHT, Gear.BACKWARD))
+        path.append(PathElement.create(u, Steering.RIGHT, Gear.FORWARD))
+        path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.LEFT, Gear.BACKWARD))
+        path.append(PathElement.create(v, Steering.RIGHT, Gear.BACKWARD))
 
     return path
 
@@ -291,11 +285,10 @@ def path7(x, y, phi):
         t = M(theta + math.pi/2 + A)
         v = M(t - phi)
 
-        if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement.create(u, Steering.RIGHT, Gear.BACKWARD))
-            path.append(PathElement.create(u, Steering.LEFT, Gear.BACKWARD))
-            path.append(PathElement.create(v, Steering.RIGHT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.RIGHT, Gear.BACKWARD))
+        path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.LEFT, Gear.BACKWARD))
+        path.append(PathElement.create(v, Steering.RIGHT, Gear.FORWARD))
 
     return path
 
@@ -318,11 +311,10 @@ def path8(x, y, phi):
         t = M(theta + math.pi/2 + A)
         v = M(t - phi + math.pi/2)
 
-        if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
-            path.append(PathElement.create(u, Steering.STRAIGHT, Gear.BACKWARD))
-            path.append(PathElement.create(v, Steering.LEFT, Gear.BACKWARD))
+        path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
+        path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.STRAIGHT, Gear.BACKWARD))
+        path.append(PathElement.create(v, Steering.LEFT, Gear.BACKWARD))
 
     return path
 
@@ -345,11 +337,10 @@ def path9(x, y, phi):
         t = M(theta + math.pi/2 - A)
         v = M(t - phi - math.pi/2)
 
-        if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
-            path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.FORWARD))
-            path.append(PathElement.create(v, Steering.LEFT, Gear.BACKWARD))
+        path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
+        path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.FORWARD))
+        path.append(PathElement.create(v, Steering.LEFT, Gear.BACKWARD))
 
     return path
 
@@ -371,11 +362,10 @@ def path10(x, y, phi):
         u = rho - 2
         v = M(phi - t - math.pi/2)
 
-        if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
-            path.append(PathElement.create(u, Steering.STRAIGHT, Gear.BACKWARD))
-            path.append(PathElement.create(v, Steering.RIGHT, Gear.BACKWARD))
+        path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
+        path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.STRAIGHT, Gear.BACKWARD))
+        path.append(PathElement.create(v, Steering.RIGHT, Gear.BACKWARD))
 
     return path
 
@@ -397,11 +387,10 @@ def path11(x, y, phi):
         u = rho - 2
         v = M(phi - t - math.pi/2)
 
-        if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
-            path.append(PathElement.create(math.pi/2, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement.create(v, Steering.RIGHT, Gear.BACKWARD))
+        path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
+        path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(math.pi/2, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(v, Steering.RIGHT, Gear.BACKWARD))
 
     return path
 
@@ -424,11 +413,10 @@ def path12(x, y, phi):
         t = M(theta + math.pi/2 + A)
         v = M(t - phi)
 
-        if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
-            path.append(PathElement.create(u, Steering.STRAIGHT, Gear.BACKWARD))
-            path.append(PathElement.create(math.pi/2, Steering.LEFT, Gear.BACKWARD))
-            path.append(PathElement.create(v, Steering.RIGHT, Gear.FORWARD))
+        path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
+        path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.STRAIGHT, Gear.BACKWARD))
+        path.append(PathElement.create(math.pi/2, Steering.LEFT, Gear.BACKWARD))
+        path.append(PathElement.create(v, Steering.RIGHT, Gear.FORWARD))
 
     return path

--- a/reeds_shepp.py
+++ b/reeds_shepp.py
@@ -72,13 +72,7 @@ def get_optimal_path(start, end):
     Return the shortest path from start to end among those that exist
     """
     paths = get_all_paths(start, end)
-    i_min = 0
-    L_min = path_length(paths[0])
-    for i in range(1, len(paths)-1):
-        L = path_length(paths[i])
-        if L <= L_min:
-            L_min, i_min = L, i
-    return paths[i_min]
+    return min(paths, key=path_length)
 
 
 def get_all_paths(start, end):

--- a/reeds_shepp.py
+++ b/reeds_shepp.py
@@ -18,6 +18,7 @@ corresponding path (if it exists) as a list of PathElements (or an empty list).
 from utils import *
 import math
 from enum import Enum
+from dataclasses import dataclass, replace
 
 
 class Steering(Enum):
@@ -31,11 +32,11 @@ class Gear(Enum):
     BACKWARD = -1
 
 
+@dataclass
 class PathElement:
-    def __init__(self, param, steering, gear):
-        self.param = param
-        self.steering = steering
-        self.gear = gear
+    param: float
+    steering: Steering
+    gear: Gear
 
     def __repr__(self):
         s = "{ Steering: " + self.steering.name + "\tGear: " + self.gear.name \
@@ -102,16 +103,17 @@ def timeflip(path):
     """
     timeflip transform described around the end of the article
     """
-    new_path = path.copy()
+    new_path = [replace(e) for e in path]
     for e in new_path:
         e.reverse_gear()
     return new_path
+
 
 def reflect(path):
     """
     reflect transform described around the end of the article
     """
-    new_path = path.copy()
+    new_path = [replace(e) for e in path]
     for e in new_path:
         e.reverse_steering()
     return new_path

--- a/reeds_shepp.py
+++ b/reeds_shepp.py
@@ -32,19 +32,18 @@ class Gear(Enum):
     BACKWARD = -1
 
 
-def PathElement(param: float, steering: Steering, gear: Gear):
-    element = _PathElement(param, steering, gear)
-    if param >= 0:
-        return element
-    else:
-        return replace(element, param=-param).reverse_gear()
-
-
 @dataclass(eq=True)
-class _PathElement:
+class PathElement:
     param: float
     steering: Steering
     gear: Gear
+
+    @classmethod
+    def create(cls, param: float, steering: Steering, gear: Gear):
+        if param >= 0:
+            return cls(param, steering, gear)
+        else:
+            return cls(-param, steering, gear).reverse_gear()
 
     def __repr__(self):
         s = "{ Steering: " + self.steering.name + "\tGear: " + self.gear.name \
@@ -132,9 +131,9 @@ def path1(x, y, phi):
     v = M(phi - t)
 
     if t >= 0 and u >= 0 and v >= 0:
-        path.append(PathElement(t, Steering.LEFT, Gear.FORWARD))
-        path.append(PathElement(u, Steering.STRAIGHT, Gear.FORWARD))
-        path.append(PathElement(v, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
+        path.append(PathElement.create(v, Steering.LEFT, Gear.FORWARD))
 
     return path
 
@@ -155,9 +154,9 @@ def path2(x, y, phi):
         v = M(t - phi)
 
         if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement(u, Steering.STRAIGHT, Gear.FORWARD))
-            path.append(PathElement(v, Steering.RIGHT, Gear.FORWARD))
+            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+            path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
+            path.append(PathElement.create(v, Steering.RIGHT, Gear.FORWARD))
 
     return path
 
@@ -181,9 +180,9 @@ def path3(x, y, phi):
         v = M(phi - t - u)
 
         if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement(u, Steering.RIGHT, Gear.BACKWARD))
-            path.append(PathElement(v, Steering.LEFT, Gear.FORWARD))
+            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+            path.append(PathElement.create(u, Steering.RIGHT, Gear.BACKWARD))
+            path.append(PathElement.create(v, Steering.LEFT, Gear.FORWARD))
 
     return path
 
@@ -207,9 +206,9 @@ def path4(x, y, phi):
         v = M(t + u - phi)
 
         if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement(u, Steering.RIGHT, Gear.BACKWARD))
-            path.append(PathElement(v, Steering.LEFT, Gear.BACKWARD))
+            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+            path.append(PathElement.create(u, Steering.RIGHT, Gear.BACKWARD))
+            path.append(PathElement.create(v, Steering.LEFT, Gear.BACKWARD))
 
     return path
 
@@ -233,9 +232,9 @@ def path5(x, y, phi):
         v = M(t - u - phi)
 
         if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement(u, Steering.RIGHT, Gear.FORWARD))
-            path.append(PathElement(v, Steering.LEFT, Gear.BACKWARD))
+            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+            path.append(PathElement.create(u, Steering.RIGHT, Gear.FORWARD))
+            path.append(PathElement.create(v, Steering.LEFT, Gear.BACKWARD))
 
     return path
 
@@ -265,10 +264,10 @@ def path6(x, y, phi):
             v = M(phi - t + 2*u)
 
         if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement(u, Steering.RIGHT, Gear.FORWARD))
-            path.append(PathElement(u, Steering.LEFT, Gear.BACKWARD))
-            path.append(PathElement(v, Steering.RIGHT, Gear.BACKWARD))
+            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+            path.append(PathElement.create(u, Steering.RIGHT, Gear.FORWARD))
+            path.append(PathElement.create(u, Steering.LEFT, Gear.BACKWARD))
+            path.append(PathElement.create(v, Steering.RIGHT, Gear.BACKWARD))
 
     return path
 
@@ -293,10 +292,10 @@ def path7(x, y, phi):
         v = M(t - phi)
 
         if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement(u, Steering.RIGHT, Gear.BACKWARD))
-            path.append(PathElement(u, Steering.LEFT, Gear.BACKWARD))
-            path.append(PathElement(v, Steering.RIGHT, Gear.FORWARD))
+            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+            path.append(PathElement.create(u, Steering.RIGHT, Gear.BACKWARD))
+            path.append(PathElement.create(u, Steering.LEFT, Gear.BACKWARD))
+            path.append(PathElement.create(v, Steering.RIGHT, Gear.FORWARD))
 
     return path
 
@@ -320,10 +319,10 @@ def path8(x, y, phi):
         v = M(t - phi + math.pi/2)
 
         if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
-            path.append(PathElement(u, Steering.STRAIGHT, Gear.BACKWARD))
-            path.append(PathElement(v, Steering.LEFT, Gear.BACKWARD))
+            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+            path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
+            path.append(PathElement.create(u, Steering.STRAIGHT, Gear.BACKWARD))
+            path.append(PathElement.create(v, Steering.LEFT, Gear.BACKWARD))
 
     return path
 
@@ -347,10 +346,10 @@ def path9(x, y, phi):
         v = M(t - phi - math.pi/2)
 
         if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement(u, Steering.STRAIGHT, Gear.FORWARD))
-            path.append(PathElement(math.pi/2, Steering.RIGHT, Gear.FORWARD))
-            path.append(PathElement(v, Steering.LEFT, Gear.BACKWARD))
+            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+            path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
+            path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.FORWARD))
+            path.append(PathElement.create(v, Steering.LEFT, Gear.BACKWARD))
 
     return path
 
@@ -373,10 +372,10 @@ def path10(x, y, phi):
         v = M(phi - t - math.pi/2)
 
         if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
-            path.append(PathElement(u, Steering.STRAIGHT, Gear.BACKWARD))
-            path.append(PathElement(v, Steering.RIGHT, Gear.BACKWARD))
+            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+            path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
+            path.append(PathElement.create(u, Steering.STRAIGHT, Gear.BACKWARD))
+            path.append(PathElement.create(v, Steering.RIGHT, Gear.BACKWARD))
 
     return path
 
@@ -399,10 +398,10 @@ def path11(x, y, phi):
         v = M(phi - t - math.pi/2)
 
         if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement(u, Steering.STRAIGHT, Gear.FORWARD))
-            path.append(PathElement(math.pi/2, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement(v, Steering.RIGHT, Gear.BACKWARD))
+            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+            path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
+            path.append(PathElement.create(math.pi/2, Steering.LEFT, Gear.FORWARD))
+            path.append(PathElement.create(v, Steering.RIGHT, Gear.BACKWARD))
 
     return path
 
@@ -426,10 +425,10 @@ def path12(x, y, phi):
         v = M(t - phi)
 
         if t >= 0 and u >= 0 and v >= 0:
-            path.append(PathElement(t, Steering.LEFT, Gear.FORWARD))
-            path.append(PathElement(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
-            path.append(PathElement(u, Steering.STRAIGHT, Gear.BACKWARD))
-            path.append(PathElement(math.pi/2, Steering.LEFT, Gear.BACKWARD))
-            path.append(PathElement(v, Steering.RIGHT, Gear.FORWARD))
+            path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+            path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
+            path.append(PathElement.create(u, Steering.STRAIGHT, Gear.BACKWARD))
+            path.append(PathElement.create(math.pi/2, Steering.LEFT, Gear.BACKWARD))
+            path.append(PathElement.create(v, Steering.RIGHT, Gear.FORWARD))
 
     return path

--- a/reeds_shepp.py
+++ b/reeds_shepp.py
@@ -32,8 +32,16 @@ class Gear(Enum):
     BACKWARD = -1
 
 
-@dataclass
-class PathElement:
+def PathElement(param: float, steering: Steering, gear: Gear):
+    element = _PathElement(param, steering, gear)
+    if param >= 0:
+        return element
+    else:
+        return replace(element, param=-param).reverse_gear()
+
+
+@dataclass(eq=True)
+class _PathElement:
     param: float
     steering: Steering
     gear: Gear

--- a/reeds_shepp.py
+++ b/reeds_shepp.py
@@ -21,50 +21,40 @@ from enum import Enum
 
 
 class Steering(Enum):
-    LEFT = 1
-    RIGHT = 2
-    STRAIGHT = 3
+    LEFT = -1
+    RIGHT = 1
+    STRAIGHT = 0
+
 
 class Gear(Enum):
     FORWARD = 1
-    BACKWARD = 2
+    BACKWARD = -1
 
-class PathElement():
+
+class PathElement:
     def __init__(self, param, steering, gear):
         self.param = param
         self.steering = steering
         self.gear = gear
 
     def __repr__(self):
-        if self.steering == Steering.LEFT: steering_str = "left"
-        elif self.steering == Steering.RIGHT: steering_str = "right"
-        else: steering_str = "straight"
-
-        if self.gear == Gear.FORWARD: gear_str = "forward"
-        else: gear_str = "backward"
-
-        s = "{ Steering: " + steering_str + "\tGear: " + gear_str \
+        s = "{ Steering: " + self.steering.name + "\tGear: " + self.gear.name \
             + "\tdistance: " + str(round(self.param, 2)) + " }"
-
         return s
 
     def reverse_steering(self):
-        if self.steering == Steering.LEFT:
-            self.steering = Steering.RIGHT
-        elif self.steering == Steering.RIGHT:
-            self.steering = Steering.LEFT
+        self.steering = Steering(-self.steering.value)
 
     def reverse_gear(self):
-        if self.gear == Gear.FORWARD:
-            self.gear = Gear.BACKWARD
-        else:
-            self.gear = Gear.FORWARD
+        self.gear = Gear(-self.gear.value)
+
 
 def path_length(path):
     """
     this one's obvious
     """
     return sum([e.param for e in path])
+
 
 def get_optimal_path(start, end):
     """

--- a/reeds_shepp.py
+++ b/reeds_shepp.py
@@ -129,8 +129,8 @@ def path1(x, y, phi):
     u, t = R(x - math.sin(phi), y - 1 + math.cos(phi))
     v = M(phi - t)
 
-    path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
     path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+    path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
     path.append(PathElement.create(v, Steering.LEFT, Gear.FORWARD))
 
     return path
@@ -150,8 +150,8 @@ def path2(x, y, phi):
         t = M(t1 + math.atan2(2, u))
         v = M(t - phi)
 
-        path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
         path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
         path.append(PathElement.create(v, Steering.RIGHT, Gear.FORWARD))
 
     return path
@@ -174,8 +174,8 @@ def path3(x, y, phi):
         u = M(math.pi - 2*A)
         v = M(phi - t - u)
 
-        path.append(PathElement.create(u, Steering.RIGHT, Gear.BACKWARD))
         path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.RIGHT, Gear.BACKWARD))
         path.append(PathElement.create(v, Steering.LEFT, Gear.FORWARD))
 
     return path
@@ -198,8 +198,8 @@ def path4(x, y, phi):
         u = M(math.pi - 2*A)
         v = M(t + u - phi)
 
-        path.append(PathElement.create(u, Steering.RIGHT, Gear.BACKWARD))
         path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.RIGHT, Gear.BACKWARD))
         path.append(PathElement.create(v, Steering.LEFT, Gear.BACKWARD))
 
     return path
@@ -222,8 +222,8 @@ def path5(x, y, phi):
         t = M(theta + math.pi/2 - A)
         v = M(t - u - phi)
 
-        path.append(PathElement.create(u, Steering.RIGHT, Gear.FORWARD))
         path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.RIGHT, Gear.FORWARD))
         path.append(PathElement.create(v, Steering.LEFT, Gear.BACKWARD))
 
     return path
@@ -252,8 +252,8 @@ def path6(x, y, phi):
             u = M(math.pi - A)
             v = M(phi - t + 2*u)
 
-        path.append(PathElement.create(u, Steering.RIGHT, Gear.FORWARD))
         path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.RIGHT, Gear.FORWARD))
         path.append(PathElement.create(u, Steering.LEFT, Gear.BACKWARD))
         path.append(PathElement.create(v, Steering.RIGHT, Gear.BACKWARD))
 
@@ -278,8 +278,8 @@ def path7(x, y, phi):
         t = M(theta + math.pi/2 + A)
         v = M(t - phi)
 
-        path.append(PathElement.create(u, Steering.RIGHT, Gear.BACKWARD))
         path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.RIGHT, Gear.BACKWARD))
         path.append(PathElement.create(u, Steering.LEFT, Gear.BACKWARD))
         path.append(PathElement.create(v, Steering.RIGHT, Gear.FORWARD))
 
@@ -303,8 +303,8 @@ def path8(x, y, phi):
         t = M(theta + math.pi/2 + A)
         v = M(t - phi + math.pi/2)
 
-        path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
         path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
         path.append(PathElement.create(u, Steering.STRAIGHT, Gear.BACKWARD))
         path.append(PathElement.create(v, Steering.LEFT, Gear.BACKWARD))
 
@@ -328,8 +328,8 @@ def path9(x, y, phi):
         t = M(theta + math.pi/2 - A)
         v = M(t - phi - math.pi/2)
 
-        path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
         path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
         path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.FORWARD))
         path.append(PathElement.create(v, Steering.LEFT, Gear.BACKWARD))
 
@@ -352,8 +352,8 @@ def path10(x, y, phi):
         u = rho - 2
         v = M(phi - t - math.pi/2)
 
-        path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
         path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
         path.append(PathElement.create(u, Steering.STRAIGHT, Gear.BACKWARD))
         path.append(PathElement.create(v, Steering.RIGHT, Gear.BACKWARD))
 
@@ -376,8 +376,8 @@ def path11(x, y, phi):
         u = rho - 2
         v = M(phi - t - math.pi/2)
 
-        path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
         path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(u, Steering.STRAIGHT, Gear.FORWARD))
         path.append(PathElement.create(math.pi/2, Steering.LEFT, Gear.FORWARD))
         path.append(PathElement.create(v, Steering.RIGHT, Gear.BACKWARD))
 
@@ -401,8 +401,8 @@ def path12(x, y, phi):
         t = M(theta + math.pi/2 + A)
         v = M(t - phi)
 
-        path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
         path.append(PathElement.create(t, Steering.LEFT, Gear.FORWARD))
+        path.append(PathElement.create(math.pi/2, Steering.RIGHT, Gear.BACKWARD))
         path.append(PathElement.create(u, Steering.STRAIGHT, Gear.BACKWARD))
         path.append(PathElement.create(math.pi/2, Steering.LEFT, Gear.BACKWARD))
         path.append(PathElement.create(v, Steering.RIGHT, Gear.FORWARD))

--- a/reeds_shepp.py
+++ b/reeds_shepp.py
@@ -123,7 +123,6 @@ def path1(x, y, phi):
     """
     Formula 8.1: CSC (same turns)
     """
-    r, theta = R(x, y)
     phi = deg2rad(phi)
     path = []
 
@@ -141,7 +140,6 @@ def path2(x, y, phi):
     """
     Formula 8.2: CSC (opposite turns)
     """
-    r, theta = R(x, y)
     phi = M(deg2rad(phi))
     path = []
 
@@ -163,7 +161,6 @@ def path3(x, y, phi):
     """
     Formula 8.3: C|C|C
     """
-    r, theta = R(x, y)
     phi = deg2rad(phi)
     path = []
 
@@ -188,7 +185,6 @@ def path4(x, y, phi):
     """
     Formula 8.4 (1): C|CC
     """
-    r, theta = R(x, y)
     phi = deg2rad(phi)
     path = []
 
@@ -213,7 +209,6 @@ def path5(x, y, phi):
     """
     Formula 8.4 (2): CC|C
     """
-    r, theta = R(x, y)
     phi = deg2rad(phi)
     path = []
 
@@ -238,7 +233,6 @@ def path6(x, y, phi):
     """
     Formula 8.7: CCu|CuC
     """
-    r, theta = R(x, y)
     phi = deg2rad(phi)
     path = []
 
@@ -270,7 +264,6 @@ def path7(x, y, phi):
     """
     Formula 8.8: C|CuCu|C
     """
-    r, theta = R(x, y)
     phi = deg2rad(phi)
     path = []
 
@@ -297,7 +290,6 @@ def path8(x, y, phi):
     """
     Formula 8.9 (1): C|C[pi/2]SC
     """
-    r, theta = R(x, y)
     phi = deg2rad(phi)
     path = []
 
@@ -323,7 +315,6 @@ def path9(x, y, phi):
     """
     Formula 8.9 (2): CSC[pi/2]|C
     """
-    r, theta = R(x, y)
     phi = deg2rad(phi)
     path = []
 
@@ -349,7 +340,6 @@ def path10(x, y, phi):
     """
     Formula 8.10 (1): C|C[pi/2]SC
     """
-    r, theta = R(x, y)
     phi = deg2rad(phi)
     path = []
 
@@ -374,7 +364,6 @@ def path11(x, y, phi):
     """
     Formula 8.10 (2): CSC[pi/2]|C
     """
-    r, theta = R(x, y)
     phi = deg2rad(phi)
     path = []
 
@@ -399,7 +388,6 @@ def path12(x, y, phi):
     """
     Formula 8.11: C|C[pi/2]SC[pi/2]|C
     """
-    r, theta = R(x, y)
     phi = deg2rad(phi)
     path = []
 

--- a/test_reeds_shepp.py
+++ b/test_reeds_shepp.py
@@ -1,0 +1,40 @@
+import unittest
+from reeds_shepp import PathElement, Steering, Gear, path_length
+
+
+class TestPathElement(unittest.TestCase):
+    def setUp(self) -> None:
+        self.element = PathElement(13, Steering.LEFT, Gear.FORWARD)
+
+    def test_repr(self):
+        self.assertEqual(
+            repr(self.element),
+            "{ Steering: LEFT	Gear: FORWARD	distance: 13 }"
+        )
+
+    def test_reverse_gear(self):
+        self.element.reverse_gear()
+        self.assertEqual(
+            self.element.gear,
+            Gear.BACKWARD
+        )
+
+    def test_reverse_steering(self):
+        self.element.reverse_steering()
+        self.assertEqual(
+            self.element.steering,
+            Steering.RIGHT
+        )
+
+
+class TestPathLength(unittest.TestCase):
+    def test_with_positive_path_elements(self):
+        path = [PathElement(1, Steering.LEFT, Gear.FORWARD) for _ in range(2)]
+        self.assertEqual(
+            path_length(path),
+            2
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_reeds_shepp.py
+++ b/test_reeds_shepp.py
@@ -1,5 +1,5 @@
 import unittest
-from reeds_shepp import PathElement, Steering, Gear, path_length
+from reeds_shepp import PathElement, Steering, Gear, path_length, timeflip, reflect
 
 
 class TestPathElement(unittest.TestCase):
@@ -34,6 +34,55 @@ class TestPathLength(unittest.TestCase):
             path_length(path),
             2
         )
+
+
+class TestTimeflip(unittest.TestCase):
+    def setUp(self) -> None:
+        self.path = [PathElement(1, Steering.LEFT, g) for g in (Gear.FORWARD, Gear.BACKWARD)]
+        self.timeflipped = timeflip(self.path)
+
+    def test_it_flips_forward_backward(self):
+        self.assertEqual(
+            self.timeflipped[0].gear,
+            Gear.BACKWARD
+        )
+        self.assertEqual(
+            self.timeflipped[1].gear,
+            Gear.FORWARD
+        )
+
+    def test_it_does_not_mutate_original_path(self):
+        self.assertEqual(
+            self.path[0].gear,
+            Gear.FORWARD,
+        )
+
+
+class TestReflect(unittest.TestCase):
+    def setUp(self) -> None:
+        self.path = [PathElement(1, s, Gear.FORWARD) for s in (Steering.LEFT, Steering.STRAIGHT, Steering.RIGHT)]
+        self.reflected = reflect(self.path)
+
+    def test_it_reflects_steering(self):
+        self.assertEqual(
+            self.reflected[0].steering,
+            Steering.RIGHT
+        )
+        self.assertEqual(
+            self.reflected[1].steering,
+            Steering.STRAIGHT
+        )
+        self.assertEqual(
+            self.reflected[2].steering,
+            Steering.LEFT
+        )
+
+    def test_it_does_not_mutate_original_path(self):
+        self.assertEqual(
+            self.path[0].steering,
+            Steering.LEFT,
+        )
+
 
 
 if __name__ == '__main__':

--- a/test_reeds_shepp.py
+++ b/test_reeds_shepp.py
@@ -13,16 +13,14 @@ class TestPathElement(unittest.TestCase):
         )
 
     def test_reverse_gear(self):
-        self.element.reverse_gear()
         self.assertEqual(
-            self.element.gear,
+            self.element.reverse_gear().gear,
             Gear.BACKWARD
         )
 
     def test_reverse_steering(self):
-        self.element.reverse_steering()
         self.assertEqual(
-            self.element.steering,
+            self.element.reverse_steering().steering,
             Steering.RIGHT
         )
 

--- a/test_reeds_shepp.py
+++ b/test_reeds_shepp.py
@@ -98,6 +98,5 @@ class TestGetOptimalPath(unittest.TestCase):
         )
 
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/test_reeds_shepp.py
+++ b/test_reeds_shepp.py
@@ -4,7 +4,7 @@ from reeds_shepp import PathElement, Steering, Gear, path_length, timeflip, refl
 
 class TestPathElement(unittest.TestCase):
     def setUp(self) -> None:
-        self.element = PathElement(13, Steering.LEFT, Gear.FORWARD)
+        self.element = PathElement.create(13, Steering.LEFT, Gear.FORWARD)
 
     def test_repr(self):
         self.assertEqual(
@@ -25,16 +25,16 @@ class TestPathElement(unittest.TestCase):
         )
 
     def test_with_negative_parameter(self):
-        element = PathElement(-1, Steering.LEFT, Gear.FORWARD)
+        element = PathElement.create(-1, Steering.LEFT, Gear.FORWARD)
         self.assertEqual(
             element,
-            PathElement(1, Steering.LEFT, Gear.BACKWARD)
+            PathElement.create(1, Steering.LEFT, Gear.BACKWARD)
         )
 
 
 class TestPathLength(unittest.TestCase):
     def test_with_positive_path_elements(self):
-        path = [PathElement(1, Steering.LEFT, Gear.FORWARD) for _ in range(2)]
+        path = [PathElement.create(1, Steering.LEFT, Gear.FORWARD) for _ in range(2)]
         self.assertEqual(
             path_length(path),
             2
@@ -43,7 +43,7 @@ class TestPathLength(unittest.TestCase):
 
 class TestTimeflip(unittest.TestCase):
     def setUp(self) -> None:
-        self.path = [PathElement(1, Steering.LEFT, g) for g in (Gear.FORWARD, Gear.BACKWARD)]
+        self.path = [PathElement.create(1, Steering.LEFT, g) for g in (Gear.FORWARD, Gear.BACKWARD)]
         self.timeflipped = timeflip(self.path)
 
     def test_it_flips_forward_backward(self):
@@ -65,7 +65,7 @@ class TestTimeflip(unittest.TestCase):
 
 class TestReflect(unittest.TestCase):
     def setUp(self) -> None:
-        self.path = [PathElement(1, s, Gear.FORWARD) for s in (Steering.LEFT, Steering.STRAIGHT, Steering.RIGHT)]
+        self.path = [PathElement.create(1, s, Gear.FORWARD) for s in (Steering.LEFT, Steering.STRAIGHT, Steering.RIGHT)]
         self.reflected = reflect(self.path)
 
     def test_it_reflects_steering(self):

--- a/test_reeds_shepp.py
+++ b/test_reeds_shepp.py
@@ -24,6 +24,13 @@ class TestPathElement(unittest.TestCase):
             Steering.RIGHT
         )
 
+    def test_with_negative_parameter(self):
+        element = PathElement(-1, Steering.LEFT, Gear.FORWARD)
+        self.assertEqual(
+            element,
+            PathElement(1, Steering.LEFT, Gear.BACKWARD)
+        )
+
 
 class TestPathLength(unittest.TestCase):
     def test_with_positive_path_elements(self):

--- a/test_reeds_shepp.py
+++ b/test_reeds_shepp.py
@@ -1,5 +1,5 @@
 import unittest
-from reeds_shepp import PathElement, Steering, Gear, path_length, timeflip, reflect
+from reeds_shepp import PathElement, Steering, Gear, path_length, timeflip, reflect, get_optimal_path
 
 
 class TestPathElement(unittest.TestCase):
@@ -86,6 +86,15 @@ class TestReflect(unittest.TestCase):
         self.assertEqual(
             self.path[0].steering,
             Steering.LEFT,
+        )
+
+
+class TestGetOptimalPath(unittest.TestCase):
+    def test_smoke_test(self):
+        path = get_optimal_path((0, 0, 0), (1, 0, 0))
+        self.assertEqual(
+            path,
+            [PathElement.create(1.0, Steering.STRAIGHT, Gear.FORWARD)]
         )
 
 


### PR DESCRIPTION
In Issue #2  two bugs have been reported:

1. Negative values for `PathElement`s are ignored in the calculation
2. Lists of `PathElement`s are copied and their element are changed afterward. This leads to changes in the original lists.

This pull request fixes these bugs. The length in `PathElement`s remains positive, but if the constructor gets a negative value for `param` it reverses the gear.

Furthermore I wrote some tests and did some refactorings, which hopefully improve code quality.